### PR TITLE
feat: enhance teamspace user management with role assignments and logo removal endpoints

### DIFF
--- a/backend/ee/enmedd/server/teamspace/models.py
+++ b/backend/ee/enmedd/server/teamspace/models.py
@@ -140,9 +140,20 @@ class Teamspace(BaseModel):
         )
 
 
+class TeamspaceUserRole(str, Enum):
+    BASIC = "basic"
+    CREATOR = "creator"
+    ADMIN = "admin"
+
+
+class UserWithRole(BaseModel):
+    user_id: UUID
+    role: Optional[str] = TeamspaceUserRole.BASIC
+
+
 class TeamspaceCreate(BaseModel):
     name: str
-    user_ids: list[UUID]
+    users: List[UserWithRole]
     cc_pair_ids: Optional[List[int]] = None
     document_set_ids: Optional[List[int]] = None
     assistant_ids: Optional[List[int]] = None
@@ -158,12 +169,6 @@ class TeamspaceUpdate(BaseModel):
 
 class TeamspaceUpdateName(BaseModel):
     name: str
-
-
-class TeamspaceUserRole(str, Enum):
-    BASIC = "basic"
-    CREATOR = "creator"
-    ADMIN = "admin"
 
 
 class UpdateUserRoleRequest(BaseModel):

--- a/backend/enmedd/auth/invited_users.py
+++ b/backend/enmedd/auth/invited_users.py
@@ -50,12 +50,7 @@ def write_invited_users(emails: list[str], teamspace_id: Optional[int] = None) -
         except KvKeyNotFoundError:
             teamspace_users = {}
 
-        if str(teamspace_id) in teamspace_users:
-            existing_emails = set(teamspace_users[str(teamspace_id)])
-            updated_emails = existing_emails.union(emails)
-            teamspace_users[str(teamspace_id)] = list(updated_emails)
-        else:
-            teamspace_users[str(teamspace_id)] = emails
+        teamspace_users[str(teamspace_id)] = emails
 
         store.store(TEAMSPACE_INVITE_USER, cast(JSON_ro, teamspace_users))
 

--- a/backend/enmedd/server/manage/users.py
+++ b/backend/enmedd/server/manage/users.py
@@ -437,7 +437,7 @@ def bulk_invite_users(
 def remove_invited_user(
     user_email: UserByEmail,
     teamspace_id: Optional[int] = None,
-    _: User | None = Depends(current_workspace_admin_user),
+    _: User | None = Depends(current_teamspace_admin_user),
 ) -> int:
     user_emails = get_invited_users(teamspace_id)
     remaining_users = [user for user in user_emails if user != user_email.user_email]


### PR DESCRIPTION
## Description
This pull request includes several changes to the `backend/ee/enmedd` module, primarily focusing on the `teamspace` and `workspace` functionalities. The most important changes include adding new user roles, updating user relationships, and introducing new API endpoints for managing workspace logos.

### Updates to user roles and relationships:

* [`backend/ee/enmedd/db/teamspace.py`](diffhunk://#diff-7963c2b9da788a54697894418d3bce2ae766afaa8616ce3f526e8867f3090cc6R238-R262): Introduced a new function `_add_user__teamspace_relationships_with_set_role__no_commit` to handle user relationships with specific roles during teamspace creation. This function replaces the existing `_add_user__teamspace_relationships__no_commit` in the `insert_teamspace` function. [[1]](diffhunk://#diff-7963c2b9da788a54697894418d3bce2ae766afaa8616ce3f526e8867f3090cc6R238-R262) [[2]](diffhunk://#diff-7963c2b9da788a54697894418d3bce2ae766afaa8616ce3f526e8867f3090cc6L389-R419)
* [`backend/ee/enmedd/server/teamspace/models.py`](diffhunk://#diff-4e8626ad439213061a1b62299bc7e807b6d2fb59225faed4b0429744f197cfbcR143-R156): Added a new class `UserWithRole` and moved `TeamspaceUserRole` to a more appropriate location in the file. Updated the `TeamspaceCreate` model to use `UserWithRole` instead of a list of user IDs. [[1]](diffhunk://#diff-4e8626ad439213061a1b62299bc7e807b6d2fb59225faed4b0429744f197cfbcR143-R156) [[2]](diffhunk://#diff-4e8626ad439213061a1b62299bc7e807b6d2fb59225faed4b0429744f197cfbcL163-L168)

### Enhancements to workspace API:

* [`backend/ee/enmedd/server/workspace/api.py`](diffhunk://#diff-a5504cf26ea778f560a4ab1bfbb3e166e5e9cc948522d9ced67f505eadb708d5R18): Added imports for `Workspace` and `_HEADERLOGO_FILENAME`. [[1]](diffhunk://#diff-a5504cf26ea778f560a4ab1bfbb3e166e5e9cc948522d9ced67f505eadb708d5R18) [[2]](diffhunk://#diff-a5504cf26ea778f560a4ab1bfbb3e166e5e9cc948522d9ced67f505eadb708d5R32)
* [`backend/ee/enmedd/server/workspace/api.py`](diffhunk://#diff-a5504cf26ea778f560a4ab1bfbb3e166e5e9cc948522d9ced67f505eadb708d5R262-R320): Introduced new endpoints `remove_logo` and `remove_header_logo` to allow administrators to delete workspace logos.

### Minor improvements:

* [`backend/ee/enmedd/server/workspace/api.py`](diffhunk://#diff-a5504cf26ea778f560a4ab1bfbb3e166e5e9cc948522d9ced67f505eadb708d5L244-R246): Temporarily set `workspace_id` to 0 in the `fetch_logo` function to handle missing workspace IDs.
* [`backend/ee/enmedd/db/teamspace.py`](diffhunk://#diff-7963c2b9da788a54697894418d3bce2ae766afaa8616ce3f526e8867f3090cc6R3): Added missing import for `List` from `typing`.
* [`backend/ee/enmedd/db/teamspace.py`](diffhunk://#diff-7963c2b9da788a54697894418d3bce2ae766afaa8616ce3f526e8867f3090cc6R17): Added missing import for `UserWithRole` from `ee.enmedd.server.teamspace.models`.


## How Has This Been Tested?
* Tested Manually


## Accepted Risk
[Any know risks or failure modes to point out to reviewers]


## Related Issue(s)
[If applicable, link to the issue(s) this PR addresses]


## Checklist:
- [x] All of the automated tests pass
- [x] All PR comments are addressed and marked resolved
- [x] If there are migrations, they have been rebased to latest main
- [x] If there are new dependencies, they are added to the requirements
- [x] If there are new environment variables, they are added to all of the deployment methods
- [x] If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- [x] Docker images build and basic functionalities work
- [x] Author has done a final read through of the PR right before merge
