### PR TITLE
bugfix: workspace and teamspace settings on creation

### DIFF
--- a/backend/ee/enmedd/server/teamspace/api.py
+++ b/backend/ee/enmedd/server/teamspace/api.py
@@ -30,6 +30,8 @@ from enmedd.db.models import User__Teamspace
 from enmedd.db.models import UserRole
 from enmedd.db.users import get_user_by_email
 from enmedd.file_store.file_store import get_default_file_store
+from enmedd.server.settings.models import Settings
+from enmedd.server.settings.store import store_settings
 from enmedd.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -132,6 +134,12 @@ def create_teamspace(
 
         db_teamspace = insert_teamspace(
             db_session, teamspace, creator_id=current_user.id
+        )
+        default_settings = Settings()
+        store_settings(
+            settings=default_settings,
+            db_session=db_session,
+            teamspace_id=db_teamspace.id,
         )
 
         return Teamspace.from_model(db_teamspace)

--- a/backend/enmedd/db/instance.py
+++ b/backend/enmedd/db/instance.py
@@ -61,21 +61,22 @@ def delete_schema(db_session: Session, schema_name: str) -> None:
 
 def insert_workspace_data(
     db_session: Session, schema_name: str, workspace: WorkspaceCreate
-) -> None:
-    """Insert workspace data into the new schema's workspace table."""
-    db_session.execute(
+) -> int:
+    """Insert workspace data into the new schema's workspace table and return workspace_id."""
+    result = db_session.execute(
         text(
             f"""
-        INSERT INTO {schema_name}.workspace (
-            instance_id, workspace_name, workspace_description, use_custom_logo,
-            custom_logo, custom_header_logo, custom_header_content,
-            brand_color, secondary_color
-        ) VALUES (
-            :instance_id, :workspace_name, :workspace_description, :use_custom_logo,
-            :custom_logo, :custom_header_logo, :custom_header_content,
-            :brand_color, :secondary_color
-        )
-    """
+            INSERT INTO {schema_name}.workspace (
+                instance_id, workspace_name, workspace_description, use_custom_logo,
+                custom_logo, custom_header_logo, custom_header_content,
+                brand_color, secondary_color
+            ) VALUES (
+                :instance_id, :workspace_name, :workspace_description, :use_custom_logo,
+                :custom_logo, :custom_header_logo, :custom_header_content,
+                :brand_color, :secondary_color
+            )
+            RETURNING id  -- Assuming `id` is the primary key column for the workspace table
+        """
         ),
         {
             "instance_id": 0,  # Adjust as needed
@@ -89,7 +90,9 @@ def insert_workspace_data(
             "secondary_color": workspace.secondary_color,
         },
     )
+    workspace_id = result.scalar()
     db_session.commit()
+    return workspace_id
 
 
 def upsert_instance(

--- a/backend/enmedd/server/settings/api.py
+++ b/backend/enmedd/server/settings/api.py
@@ -68,7 +68,8 @@ def put_settings(
     db: Session = Depends(get_session),
     workspace_id: Optional[int] = 0,  # temporary set to 0
     teamspace_id: Optional[int] = None,
-    _: User | None = Depends(current_teamspace_admin_user),
+    _: User
+    | None = Depends(current_teamspace_admin_user or current_workspace_admin_user),
 ) -> None:
     try:
         settings.check_validity()

--- a/backend/enmedd/server/settings/models.py
+++ b/backend/enmedd/server/settings/models.py
@@ -43,7 +43,7 @@ class Settings(BaseModel):
     maximum_chat_retention_days: int | None = None
     gpu_enabled: bool | None = False
     num_indexing_workers: int | None = 1
-    vespa_searcher_threads: int | None = 1
+    vespa_searcher_threads: int | None = 2
     smtp_server: Optional[str] = None
     smtp_port: Optional[int] = None
     smtp_username: Optional[str] = None


### PR DESCRIPTION
## Description
This pull request includes several changes to the backend of the `enmedd` server, focusing on the creation and management of workspaces and teamspaces, as well as improvements to the settings management. The most important changes include adding default settings when creating new workspaces and teamspaces, modifying the `insert_workspace_data` function to return the workspace ID, and decrypting the SMTP password when loading settings.

Changes to workspace and teamspace creation:

* [`backend/ee/enmedd/server/instance/api.py`](diffhunk://#diff-fd99e8991935907132de66fd267f8dbabea5ef8aa756f74cfdc0c4629acf596eR23-R24): Added default settings when creating a new workspace by importing `Settings` and `store_settings`, and storing default settings after inserting workspace data. [[1]](diffhunk://#diff-fd99e8991935907132de66fd267f8dbabea5ef8aa756f74cfdc0c4629acf596eR23-R24) [[2]](diffhunk://#diff-fd99e8991935907132de66fd267f8dbabea5ef8aa756f74cfdc0c4629acf596eL47-R57)
* [`backend/ee/enmedd/server/teamspace/api.py`](diffhunk://#diff-86fd5d7807c62e85c6b3495ac997e2e42fb2f164b30fc1d618216c9ab1c4ba8fR33-R34): Added default settings when creating a new teamspace by importing `Settings` and `store_settings`, and storing default settings after inserting teamspace data. [[1]](diffhunk://#diff-86fd5d7807c62e85c6b3495ac997e2e42fb2f164b30fc1d618216c9ab1c4ba8fR33-R34) [[2]](diffhunk://#diff-86fd5d7807c62e85c6b3495ac997e2e42fb2f164b30fc1d618216c9ab1c4ba8fR138-R143)

Changes to settings management:

* [`backend/enmedd/db/instance.py`](diffhunk://#diff-613a6754716248bd42bdd190262091ffd5e47ca8483db1461875667e1216e102L64-R66): Modified the `insert_workspace_data` function to return the workspace ID after inserting workspace data. [[1]](diffhunk://#diff-613a6754716248bd42bdd190262091ffd5e47ca8483db1461875667e1216e102L64-R66) [[2]](diffhunk://#diff-613a6754716248bd42bdd190262091ffd5e47ca8483db1461875667e1216e102R78) [[3]](diffhunk://#diff-613a6754716248bd42bdd190262091ffd5e47ca8483db1461875667e1216e102R93-R95)
* [`backend/enmedd/server/settings/store.py`](diffhunk://#diff-be926a99e59aea2adde539976f31c2e42b0ebaa0c8278dc5216b451a995ce78cR70-R74): Decrypted the SMTP password when loading settings, and added schema name handling in the `store_settings` function to set and reset the search path. [[1]](diffhunk://#diff-be926a99e59aea2adde539976f31c2e42b0ebaa0c8278dc5216b451a995ce78cR70-R74) [[2]](diffhunk://#diff-be926a99e59aea2adde539976f31c2e42b0ebaa0c8278dc5216b451a995ce78cL78-R85) [[3]](diffhunk://#diff-be926a99e59aea2adde539976f31c2e42b0ebaa0c8278dc5216b451a995ce78cL87-R100) [[4]](diffhunk://#diff-be926a99e59aea2adde539976f31c2e42b0ebaa0c8278dc5216b451a995ce78cR151-R153)

Other improvements:

* [`backend/enmedd/server/settings/models.py`](diffhunk://#diff-b9bc71b23c7624b94294b142c955fafc0385b38c250468eb567bc6306dcf0327L46-R46): Changed the default value of `vespa_searcher_threads` in the `Settings` class from 1 to 2.
* [`backend/enmedd/server/settings/api.py`](diffhunk://#diff-58a15e82c6da614f59fb8f68b582450d999c01ed5117bbe696180fec77e62706L71-R72): Updated the `put_settings` function to accept either a teamspace admin user or a workspace admin user.


## How Has This Been Tested?
[Describe the tests you ran to verify your changes]


## Accepted Risk
[Any know risks or failure modes to point out to reviewers]


## Related Issue(s)
[If applicable, link to the issue(s) this PR addresses]


## Checklist:
- [ ] All of the automated tests pass
- [ ] All PR comments are addressed and marked resolved
- [ ] If there are migrations, they have been rebased to latest main
- [ ] If there are new dependencies, they are added to the requirements
- [ ] If there are new environment variables, they are added to all of the deployment methods
- [ ] If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- [ ] Docker images build and basic functionalities work
- [ ] Author has done a final read through of the PR right before merge
