### PR TITLE
feat: add field validators to strip whitespace from various model fields

### DIFF
--- a/backend/ee/enmedd/server/api_key/models.py
+++ b/backend/ee/enmedd/server/api_key/models.py
@@ -1,4 +1,5 @@
 from pydantic import BaseModel
+from pydantic import field_validator
 
 from enmedd.auth.schemas import UserRole
 
@@ -6,3 +7,9 @@ from enmedd.auth.schemas import UserRole
 class APIKeyArgs(BaseModel):
     name: str | None = None
     role: UserRole = UserRole.BASIC
+
+    @field_validator("name", mode="before")
+    def strip_whitespace(cls, value):
+        if isinstance(value, str):
+            return value.strip()
+        return value

--- a/backend/ee/enmedd/server/teamspace/models.py
+++ b/backend/ee/enmedd/server/teamspace/models.py
@@ -4,6 +4,7 @@ from typing import Optional
 from uuid import UUID
 
 from pydantic import BaseModel
+from pydantic import field_validator
 
 from enmedd.db.models import Teamspace as TeamspaceModel
 from enmedd.server.documents.models import ConnectorCredentialPairDescriptor
@@ -146,6 +147,12 @@ class TeamspaceCreate(BaseModel):
     assistant_ids: Optional[List[int]] = None
     workspace_id: Optional[int] = 0
 
+    @field_validator("name", "descriptions", mode="before")
+    def strip_whitespace(cls, value):
+        if isinstance(value, str):
+            return value.strip()
+        return value
+
 
 class TeamspaceUpdate(BaseModel):
     user_ids: list[UUID]
@@ -158,7 +165,19 @@ class TeamspaceUpdateName(BaseModel):
     name: str
     description: Optional[str] = None
 
+    @field_validator("name", "description", mode="before")
+    def strip_whitespace(cls, value):
+        if isinstance(value, str):
+            return value.strip()
+        return value
+
 
 class UpdateUserRoleRequest(BaseModel):
     user_email: str
     new_role: TeamspaceUserRole
+
+    @field_validator("user_email", mode="before")
+    def strip_whitespace(cls, value):
+        if isinstance(value, str):
+            return value.strip()
+        return value

--- a/backend/ee/enmedd/server/workspace/models.py
+++ b/backend/ee/enmedd/server/workspace/models.py
@@ -4,6 +4,7 @@ from typing import Optional
 from uuid import UUID
 
 from pydantic import BaseModel
+from pydantic import field_validator
 
 from ee.enmedd.server.teamspace.models import Teamspace
 from enmedd.db.models import Workspace as WorkspaceModel
@@ -78,6 +79,12 @@ class WorkspaceCreate(BaseModel):
     secondary_color: Optional[str] = None
     user_ids: list[UUID]
 
+    @field_validator("workspace_name", "workspace_description", mode="before")
+    def strip_whitespace(cls, value):
+        if isinstance(value, str):
+            return value.strip()
+        return value
+
 
 class WorkspaceUpdate(BaseModel):
     workspace_name: Optional[str] = None
@@ -90,6 +97,12 @@ class WorkspaceUpdate(BaseModel):
     secondary_color: Optional[str] = None
     user_ids: Optional[list[UUID]] = None
 
+    @field_validator("workspace_name", "workspace_description", mode="before")
+    def strip_whitespace(cls, value):
+        if isinstance(value, str):
+            return value.strip()
+        return value
+
 
 class InstanceSubscriptionPlan(str, Enum):
     ENTERPRISE = "enterprise"
@@ -100,6 +113,12 @@ class Instance(BaseModel):
     instance_name: Optional[str] = None
     subscription_plan: InstanceSubscriptionPlan
     owner_id: UUID
+
+    @field_validator("instance_name", mode="before")
+    def strip_whitespace(cls, value):
+        if isinstance(value, str):
+            return value.strip()
+        return value
 
 
 class AnalyticsScriptUpload(BaseModel):

--- a/backend/enmedd/auth/schemas.py
+++ b/backend/enmedd/auth/schemas.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 from fastapi_users import schemas
 from pydantic import EmailStr
+from pydantic import field_validator
 
 
 class UserRole(str, Enum):
@@ -55,6 +56,14 @@ class UserCreate(schemas.BaseUserCreate):
     billing_email_address: Optional[EmailStr] = None
     vat: Optional[str] = None
 
+    @field_validator(
+        "full_name", "company_name", "company_billing", "vat", mode="before"
+    )
+    def strip_whitespace(cls, value):
+        if isinstance(value, str):
+            return value.strip()
+        return value
+
 
 class UserUpdate(schemas.BaseUserUpdate):
     role: Optional[UserRole] = None
@@ -66,7 +75,21 @@ class UserUpdate(schemas.BaseUserUpdate):
     billing_email_address: Optional[EmailStr] = None
     vat: Optional[str] = None
 
+    @field_validator(
+        "full_name", "company_name", "company_billing", "vat", mode="before"
+    )
+    def strip_whitespace(cls, value):
+        if isinstance(value, str):
+            return value.strip()
+        return value
+
 
 class ChangePassword(schemas.BaseUserUpdate):
     new_password: str
     current_password: str
+
+    @field_validator("new_password", "current_password", mode="before")
+    def strip_whitespace(cls, value):
+        if isinstance(value, str):
+            return value.strip()
+        return value

--- a/backend/enmedd/server/documents/models.py
+++ b/backend/enmedd/server/documents/models.py
@@ -5,6 +5,7 @@ from uuid import UUID
 
 from pydantic import BaseModel
 from pydantic import Field
+from pydantic import field_validator
 from pydantic import model_validator
 
 from enmedd.configs.app_configs import MASK_CREDENTIAL_PREFIX
@@ -50,6 +51,12 @@ class ConnectorBase(BaseModel):
     refresh_freq: int | None = None
     prune_freq: int | None = None
     indexing_start: datetime | None = None
+
+    @field_validator("name", mode="before")
+    def strip_whitespace(cls, value):
+        if isinstance(value, str):
+            return value.strip()
+        return value
 
 
 class ConnectorUpdateRequest(ConnectorBase):
@@ -103,6 +110,12 @@ class CredentialBase(BaseModel):
     source: DocumentSource
     name: str | None = None
     groups: list[int] = Field(default_factory=list)
+
+    @field_validator("name", mode="before")
+    def strip_whitespace(cls, value):
+        if isinstance(value, str):
+            return value.strip()
+        return value
 
 
 class CredentialSnapshot(CredentialBase):

--- a/backend/enmedd/server/features/assistant/models.py
+++ b/backend/enmedd/server/features/assistant/models.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from pydantic import BaseModel
 from pydantic import Field
+from pydantic import field_validator
 
 from enmedd.db.models import Assistant
 from enmedd.db.models import StarterMessage
@@ -42,6 +43,12 @@ class CreateAssistantRequest(BaseModel):
     is_default_assistant: bool = False
     display_priority: int | None = None
     search_start_date: datetime | None = None
+
+    @field_validator("name", "description", mode="before")
+    def strip_whitespace(cls, value):
+        if isinstance(value, str):
+            return value.strip()
+        return value
 
 
 class AssistantSnapshot(BaseModel):

--- a/backend/enmedd/server/features/document_set/models.py
+++ b/backend/enmedd/server/features/document_set/models.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from pydantic import BaseModel
 from pydantic import Field
+from pydantic import field_validator
 
 from enmedd.db.models import DocumentSet as DocumentSetDBModel
 from enmedd.server.documents.models import ConnectorCredentialPairDescriptor
@@ -22,6 +23,12 @@ class DocumentSetCreationRequest(BaseModel):
     users: list[UUID] = Field(default_factory=list)
     groups: list[int] = Field(default_factory=list)
 
+    @field_validator("name", "description", mode="before")
+    def strip_whitespace(cls, value):
+        if isinstance(value, str):
+            return value.strip()
+        return value
+
 
 class DocumentSetUpdateRequest(BaseModel):
     id: int
@@ -31,6 +38,12 @@ class DocumentSetUpdateRequest(BaseModel):
     # For Private Document Sets, who should be able to access these
     users: List[UUID]
     groups: List[int]
+
+    @field_validator("description", mode="before")
+    def strip_whitespace(cls, value):
+        if isinstance(value, str):
+            return value.strip()
+        return value
 
 
 class CheckDocSetPublicRequest(BaseModel):

--- a/backend/enmedd/server/features/input_prompt/models.py
+++ b/backend/enmedd/server/features/input_prompt/models.py
@@ -1,6 +1,7 @@
 from uuid import UUID
 
 from pydantic import BaseModel
+from pydantic import field_validator
 
 from enmedd.db.models import InputPrompt
 from enmedd.utils.logger import setup_logger
@@ -13,11 +14,23 @@ class CreateInputPromptRequest(BaseModel):
     content: str
     is_public: bool
 
+    @field_validator("prompt", "content", mode="before")
+    def strip_whitespace(cls, value):
+        if isinstance(value, str):
+            return value.strip()
+        return value
+
 
 class UpdateInputPromptRequest(BaseModel):
     prompt: str
     content: str
     active: bool
+
+    @field_validator("prompt", "content", mode="before")
+    def strip_whitespace(cls, value):
+        if isinstance(value, str):
+            return value.strip()
+        return value
 
 
 class InputPromptResponse(BaseModel):

--- a/backend/enmedd/server/features/input_prompt/models.py
+++ b/backend/enmedd/server/features/input_prompt/models.py
@@ -14,7 +14,7 @@ class CreateInputPromptRequest(BaseModel):
     content: str
     is_public: bool
 
-    @field_validator("prompt", "content", mode="before")
+    @field_validator("prompt", mode="before")
     def strip_whitespace(cls, value):
         if isinstance(value, str):
             return value.strip()
@@ -26,7 +26,7 @@ class UpdateInputPromptRequest(BaseModel):
     content: str
     active: bool
 
-    @field_validator("prompt", "content", mode="before")
+    @field_validator("prompt", mode="before")
     def strip_whitespace(cls, value):
         if isinstance(value, str):
             return value.strip()

--- a/backend/enmedd/server/features/prompt/models.py
+++ b/backend/enmedd/server/features/prompt/models.py
@@ -13,9 +13,7 @@ class CreatePromptRequest(BaseModel):
     datetime_aware: bool = False
     assistant_ids: list[int] | None = None
 
-    @field_validator(
-        "name", "description", "system_prompt", "task_prompt", mode="before"
-    )
+    @field_validator("name", "description", mode="before")
     def strip_whitespace(cls, value):
         if isinstance(value, str):
             return value.strip()

--- a/backend/enmedd/server/features/prompt/models.py
+++ b/backend/enmedd/server/features/prompt/models.py
@@ -1,4 +1,5 @@
 from pydantic import BaseModel
+from pydantic import field_validator
 
 from enmedd.db.models import Prompt
 
@@ -11,6 +12,14 @@ class CreatePromptRequest(BaseModel):
     include_citations: bool = False
     datetime_aware: bool = False
     assistant_ids: list[int] | None = None
+
+    @field_validator(
+        "name", "description", "system_prompt", "task_prompt", mode="before"
+    )
+    def strip_whitespace(cls, value):
+        if isinstance(value, str):
+            return value.strip()
+        return value
 
 
 class PromptSnapshot(BaseModel):

--- a/backend/enmedd/server/manage/llm/models.py
+++ b/backend/enmedd/server/manage/llm/models.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING
 
 from pydantic import BaseModel
 from pydantic import Field
+from pydantic import field_validator
 
 from enmedd.llm.llm_provider_options import fetch_models_for_provider
 
@@ -21,6 +22,12 @@ class TestLLMRequest(BaseModel):
     # model level
     default_model_name: str
     fast_default_model_name: str | None = None
+
+    @field_validator("provider", "default_model_name", mode="before")
+    def strip_whitespace(cls, value):
+        if isinstance(value, str):
+            return value.strip()
+        return value
 
 
 class LLMProviderDescriptor(BaseModel):


### PR DESCRIPTION
## Description
This pull request introduces several changes across multiple files to add `field_validator` methods for stripping whitespace from string fields in various Pydantic models. These changes ensure that any leading or trailing whitespace is removed from the input values before they are processed further.

### Key Changes:

#### Adding `field_validator` for Whitespace Stripping:

* **API Key Models:**
  * Added `field_validator` to strip whitespace from the `name` field in `APIKeyArgs`.

* **Teamspace Models:**
  * Added `field_validator` to strip whitespace from the `name` and `descriptions` fields in `TeamspaceCreate`.
  * Added `field_validator` to strip whitespace from the `name` and `description` fields in `TeamspaceUpdateName`.
  * Added `field_validator` to strip whitespace from the `user_email` field in `UpdateUserRoleRequest`.

* **Workspace Models:**
  * Added `field_validator` to strip whitespace from the `workspace_name` and `workspace_description` fields in `WorkspaceCreate` and `WorkspaceUpdate`. [[1]](diffhunk://#diff-428aa7e3c03bef9255766ac0c9b07b79e8ff987c7e6adbab1f2d198f50478ae4R82-R87) [[2]](diffhunk://#diff-428aa7e3c03bef9255766ac0c9b07b79e8ff987c7e6adbab1f2d198f50478ae4R100-R105)
  * Added `field_validator` to strip whitespace from the `instance_name` field in `Instance`.

* **Auth Schemas:**
  * Added `field_validator` to strip whitespace from various fields in `UserCreate`, `UserUpdate`, and `ChangePassword`. [[1]](diffhunk://#diff-39d388a444747e25ea5d0ec364fdcf9a596fe82d4841f70ab7742c7d2a015c9dR59-R66) [[2]](diffhunk://#diff-39d388a444747e25ea5d0ec364fdcf9a596fe82d4841f70ab7742c7d2a015c9dR78-R95)

* **Document Models:**
  * Added `field_validator` to strip whitespace from the `name` field in `ConnectorBase` and `CredentialBase`. [[1]](diffhunk://#diff-7b1bc5849a1d5ef0b5d2e09f7ac7683191515ba4204f0b245877ccd9ce2b5ae0R55-R60) [[2]](diffhunk://#diff-7b1bc5849a1d5ef0b5d2e09f7ac7683191515ba4204f0b245877ccd9ce2b5ae0R114-R119)

* **Assistant Models:**
  * Added `field_validator` to strip whitespace from the `name` and `description` fields in `CreateAssistantRequest`.

* **Document Set Models:**
  * Added `field_validator` to strip whitespace from the `name` and `description` fields in `DocumentSetCreationRequest` and `DocumentSetUpdateRequest`. [[1]](diffhunk://#diff-0b2aa80f15030bebcea075cdc0740e3ac5c21594b1e05d1179f9d198ae083374R26-R31) [[2]](diffhunk://#diff-0b2aa80f15030bebcea075cdc0740e3ac5c21594b1e05d1179f9d198ae083374R42-R47)

* **Input Prompt Models:**
  * Added `field_validator` to strip whitespace from the `prompt` and `content` fields in `CreateInputPromptRequest` and `UpdateInputPromptRequest`.

* **Prompt Models:**
  * Added `field_validator` to strip whitespace from various fields in `CreatePromptRequest`.

* **LLM Models:**
  * Added `field_validator` to strip whitespace from the `provider` and `default_model_name` fields in `TestLLMRequest`.



## Checklist:
- [x] All of the automated tests pass
- [x] All changes has been tested locally through Docker
- [x] If there are database revisions, all the Docker files are updated
- [x] If there are new dependencies, they are added to the requirements text files
- [x] If there are new environment variables, they are added to all of the deployment methods
- [x] If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- [x] Author has done a final read through of the PR right before merge
