### PR TITLE
feat: remove user context from TeamspaceCreationForm and update exist…

### DIFF
--- a/web/src/app/ee/admin/teams/TeamspaceCreationForm.tsx
+++ b/web/src/app/ee/admin/teams/TeamspaceCreationForm.tsx
@@ -20,7 +20,6 @@ import { DocumentSets } from "./DocumentSets";
 import { Assistants } from "./Assistants";
 import { useRouter } from "next/navigation";
 import { ImageUpload } from "@/app/admin/settings/ImageUpload";
-import { useUser } from "@/components/user/UserProvider";
 
 interface TeamspaceCreationFormProps {
   onClose: () => void;
@@ -41,7 +40,6 @@ export const TeamspaceCreationForm = ({
 }: TeamspaceCreationFormProps) => {
   const router = useRouter();
   const [selectedFiles, setSelectedFiles] = useState<File | null>(null);
-  const { user } = useUser();
   // const [tokenBudget, setTokenBudget] = useState(0);
   // const [periodHours, setPeriodHours] = useState(0);
   const isUpdate = existingTeamspace !== undefined;
@@ -186,9 +184,7 @@ export const TeamspaceCreationForm = ({
                   <UserEditor
                     selectedUserIds={values.users.map((user) => user.user_id)}
                     allUsers={users}
-                    existingUsers={
-                      user ? [{ user_id: user.id, role: "admin" }] : []
-                    }
+                    existingUsers={values.users}
                     onAddUser={(newUser) => {
                       setFieldValue("users", [...values.users, newUser]);
                     }}


### PR DESCRIPTION
## Description
This pull request includes several changes to the `TeamspaceCreationForm` component in the `web/src/app/ee/admin/teams/TeamspaceCreationForm.tsx` file. The most important changes involve removing the `useUser` hook and updating how existing users are handled in the `UserEditor` component.

Key changes:

* Removed import and usage of the `useUser` hook from the `TeamspaceCreationForm` component. [[1]](diffhunk://#diff-34760d740c7ea2b2b25f4fdf048421d5761606791f630ba5646bf78ac7e19d63L23) [[2]](diffhunk://#diff-34760d740c7ea2b2b25f4fdf048421d5761606791f630ba5646bf78ac7e19d63L44)
* Updated `existingUsers` prop in `UserEditor` to use `values.users` directly instead of conditionally including the current user.



## Checklist:
- [ ] All of the automated tests pass
- [ ] All changes has been tested locally through Docker
- [ ] If there are database revisions, all the Docker files are updated
- [ ] If there are new dependencies, they are added to the requirements text files
- [ ] If there are new environment variables, they are added to all of the deployment methods
- [ ] If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- [ ] Author has done a final read through of the PR right before merge
