### PR TITLE
feat: allow signup for non-invited users;

### DIFF
--- a/backend/enmedd/auth/users.py
+++ b/backend/enmedd/auth/users.py
@@ -1,5 +1,5 @@
-import uuid
 import json
+import uuid
 from collections.abc import AsyncGenerator
 from datetime import datetime
 from datetime import timezone
@@ -165,10 +165,10 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         request: Optional[Request] = None,
     ) -> User:
         # additional checks for user that is being invited
-        if (request != None):
+        if request is not None:
             requestBody: str = await request.body()
             requestBody: dict = json.loads(requestBody)
-            if ("token" in requestBody.keys() and requestBody.get("token") != ""):
+            if "token" in requestBody.keys() and requestBody.get("token") != "":
                 verify_email_is_invited(user_create.email)
 
         # strict checking of allowed domain (invited or not)

--- a/backend/enmedd/auth/users.py
+++ b/backend/enmedd/auth/users.py
@@ -1,4 +1,5 @@
 import uuid
+import json
 from collections.abc import AsyncGenerator
 from datetime import datetime
 from datetime import timezone
@@ -156,14 +157,26 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
     reset_password_token_secret = USER_AUTH_SECRET
     verification_token_secret = USER_AUTH_SECRET
 
+    # function called in /auth/register
     async def create(
         self,
         user_create: schemas.UC | UserCreate,
         safe: bool = False,
         request: Optional[Request] = None,
     ) -> User:
-        verify_email_is_invited(user_create.email)
+        # additional checks for user that is being invited
+        if (request != None):
+            requestBody: str = await request.body()
+            requestBody: dict = json.loads(requestBody)
+            if ("token" in requestBody.keys() and requestBody.get("token") != ""):
+                verify_email_is_invited(user_create.email)
+
+        # strict checking of allowed domain (invited or not)
         verify_email_domain(user_create.email)
+
+        # condition to check if the account created is the first account
+        # first account -> set it to admin by default
+        # other condition -> set the role based on the given role param (BASIC is the default)
         if hasattr(user_create, "role"):
             user_count = await get_user_count()
             if user_count == 0 or user_create.email in get_default_admin_user_emails():

--- a/web/src/app/auth/signup/SignupForms.tsx
+++ b/web/src/app/auth/signup/SignupForms.tsx
@@ -103,7 +103,8 @@ export function SignupForms({ shouldVerify }: { shouldVerify?: boolean }) {
       values.full_name,
       values.company_name,
       values.email,
-      values.password
+      values.password,
+      token
     );
 
     if (!response.ok) {
@@ -124,6 +125,7 @@ export function SignupForms({ shouldVerify }: { shouldVerify?: boolean }) {
       return;
     }
 
+    // logs in data after signing up
     const loginResponse = await basicLogin(values.email, values.password);
     if (loginResponse.ok) {
       if (token) {

--- a/web/src/lib/user.ts
+++ b/web/src/lib/user.ts
@@ -61,7 +61,8 @@ export const basicSignup = async (
   full_name: string,
   company_name: string,
   email: string,
-  password: string
+  password: string,
+  token?: string
 ) => {
   const response = await fetch("/api/auth/register", {
     method: "POST",
@@ -74,6 +75,7 @@ export const basicSignup = async (
       company_name,
       email,
       password,
+      token,
     }),
   });
   return response;


### PR DESCRIPTION
## Description
Added additional checks to allow users that are not invited to register, but is still strict when it comes to validating email domains.

Changes on frontend is also added for double checks in `token` url param.

## Checklist:
- [X] All changes has been tested locally through Docker
- [ ] If there are new dependencies, they are added to the requirements text files
- [ ] If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- [ ] Author has done a final read through of the PR right before merge
