### PR TITLE
fix: use default SMTP configurations if not set in settings

### DIFF
--- a/backend/enmedd/server/settings/store.py
+++ b/backend/enmedd/server/settings/store.py
@@ -7,6 +7,10 @@ from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from enmedd.auth.users import current_workspace_admin_user
+from enmedd.configs.app_configs import SMTP_PASS
+from enmedd.configs.app_configs import SMTP_PORT
+from enmedd.configs.app_configs import SMTP_SERVER
+from enmedd.configs.app_configs import SMTP_USER
 from enmedd.db.models import TeamspaceSettings
 from enmedd.db.models import User
 from enmedd.db.models import WorkspaceSettings
@@ -73,10 +77,10 @@ def load_settings(
             maximum_chat_retention_days=settings_record.maximum_chat_retention_days,
             num_indexing_workers=settings_record.num_indexing_workers,
             vespa_searcher_threads=settings_record.vespa_searcher_threads,
-            smtp_port=settings_record.smtp_port,
-            smtp_server=settings_record.smtp_server,
-            smtp_username=settings_record.smtp_username,
-            smtp_password=settings_record.smtp_password,
+            smtp_port=settings_record.smtp_port or SMTP_PORT,
+            smtp_server=settings_record.smtp_server or SMTP_SERVER,
+            smtp_username=settings_record.smtp_username or SMTP_USER,
+            smtp_password=settings_record.smtp_password or SMTP_PASS,
         )
 
     return Settings()


### PR DESCRIPTION
## Description
This pull request includes changes to the `backend/enmedd/server/settings/store.py` file to enhance the loading of SMTP settings by incorporating default values from the application configuration.

Enhancements to SMTP settings loading:

* Added imports for `SMTP_PASS`, `SMTP_PORT`, `SMTP_SERVER`, and `SMTP_USER` from `enmedd.configs.app_configs` to use as default values.
* Modified the `load_settings` function to use the imported default values for `smtp_port`, `smtp_server`, `smtp_username`, and `smtp_password` if they are not set in `settings_record`.



## Checklist:
- [ ] All of the automated tests pass
- [ ] All changes has been tested locally through Docker
- [ ] If there are database revisions, all the Docker files are updated
- [ ] If there are new dependencies, they are added to the requirements text files
- [ ] If there are new environment variables, they are added to all of the deployment methods
- [ ] If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- [ ] Author has done a final read through of the PR right before merge
