### PR TITLE
hotfix/not-working-depends-using-or

### DIFF
--- a/backend/ee/enmedd/server/teamspace/api.py
+++ b/backend/ee/enmedd/server/teamspace/api.py
@@ -22,6 +22,7 @@ from ee.enmedd.server.workspace.store import upload_teamspace_logo
 from enmedd.auth.users import current_teamspace_admin_user
 from enmedd.auth.users import current_user
 from enmedd.auth.users import current_workspace_admin_user
+from enmedd.auth.users import current_workspace_or_teamspace_admin_user
 from enmedd.db.engine import get_session
 from enmedd.db.models import Teamspace as TeamspaceModel
 from enmedd.db.models import Teamspace__ConnectorCredentialPair
@@ -189,7 +190,7 @@ def create_teamspace(
 def patch_teamspace(
     teamspace_id: int,
     teamspace: TeamspaceUpdate,
-    _: User = Depends(current_workspace_admin_user or current_teamspace_admin_user),
+    _: User = Depends(current_workspace_or_teamspace_admin_user),
     db_session: Session = Depends(get_session),
 ) -> Teamspace:
     try:
@@ -228,7 +229,7 @@ def patch_teamspace(
 @admin_router.delete("/admin/teamspace/{teamspace_id}")
 def delete_teamspace(
     teamspace_id: int,
-    _: User = Depends(current_workspace_admin_user or current_teamspace_admin_user),
+    _: User = Depends(current_workspace_or_teamspace_admin_user),
     db_session: Session = Depends(get_session),
 ) -> None:
     try:
@@ -363,7 +364,7 @@ def update_teamspace_user_role(
 def add_teamspace_users(
     teamspace_id: int,
     emails: list[str],
-    _: User = Depends(current_workspace_admin_user or current_teamspace_admin_user),
+    _: User = Depends(current_workspace_or_teamspace_admin_user),
     db_session: Session = Depends(get_session),
 ) -> None:
     added_users = []

--- a/backend/enmedd/auth/users.py
+++ b/backend/enmedd/auth/users.py
@@ -517,3 +517,16 @@ async def current_teamspace_admin_user(
         status_code=status.HTTP_403_FORBIDDEN,
         detail="Access denied. User is neither an admin nor the creator of this teamspace.",
     )
+
+
+def current_workspace_or_teamspace_admin_user(
+    teamspace_id: Optional[int] = None,
+    user: User | None = Depends(current_user),
+    db_session: Session = Depends(get_session),
+) -> User:
+    try:
+        return current_workspace_admin_user(user=user)
+    except HTTPException:
+        return current_teamspace_admin_user(
+            teamspace_id=teamspace_id, user=user, db_session=db_session
+        )

--- a/backend/enmedd/server/auth_check.py
+++ b/backend/enmedd/server/auth_check.py
@@ -9,6 +9,7 @@ from enmedd.auth.users import current_teamspace_admin_user
 from enmedd.auth.users import current_user
 from enmedd.auth.users import current_user_with_expired_token
 from enmedd.auth.users import current_workspace_admin_user
+from enmedd.auth.users import current_workspace_or_teamspace_admin_user
 from enmedd.configs.app_configs import APP_API_PREFIX
 from enmedd.server.enmedd_api.ingestion import api_key_dep
 
@@ -101,6 +102,7 @@ def check_router_auth(
                     or depends_fn == current_teamspace_admin_user
                     or depends_fn == api_key_dep
                     or depends_fn == current_user_with_expired_token
+                    or depends_fn == current_workspace_or_teamspace_admin_user
                 ):
                     found_auth = True
                     break

--- a/backend/enmedd/server/settings/api.py
+++ b/backend/enmedd/server/settings/api.py
@@ -9,9 +9,9 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
 from ee.enmedd.utils.encryption import encrypt_password
-from enmedd.auth.users import current_teamspace_admin_user
 from enmedd.auth.users import current_user
 from enmedd.auth.users import current_workspace_admin_user
+from enmedd.auth.users import current_workspace_or_teamspace_admin_user
 from enmedd.auth.users import is_user_admin
 from enmedd.configs.constants import KV_REINDEX_KEY
 from enmedd.configs.constants import NotificationType
@@ -68,8 +68,7 @@ def put_settings(
     db: Session = Depends(get_session),
     workspace_id: Optional[int] = 0,  # temporary set to 0
     teamspace_id: Optional[int] = None,
-    _: User
-    | None = Depends(current_teamspace_admin_user or current_workspace_admin_user),
+    _: User | None = Depends(current_workspace_or_teamspace_admin_user),
 ) -> None:
     try:
         settings.check_validity()


### PR DESCRIPTION
## Description
This pull request introduces a new function `current_workspace_or_teamspace_admin_user` and updates various endpoints to use this function for authorization checks. The goal is to consolidate the logic for determining if a user is either a workspace admin or a teamspace admin.

Authorization Function Consolidation:

* [`backend/enmedd/auth/users.py`](diffhunk://#diff-8fade42cc8211d51ec28c7eeb650d59aa3ff762a351fa1a983fb2f43ccd814d8R520-R532): Added the `current_workspace_or_teamspace_admin_user` function to handle both workspace and teamspace admin checks.

Updates to API Endpoints:

* [`backend/ee/enmedd/server/teamspace/api.py`](diffhunk://#diff-86fd5d7807c62e85c6b3495ac997e2e42fb2f164b30fc1d618216c9ab1c4ba8fL192-R193): Replaced the existing admin user checks with `current_workspace_or_teamspace_admin_user` in the `create_teamspace`, `patch_teamspace`, `delete_teamspace`, and `add_teamspace_users` functions. [[1]](diffhunk://#diff-86fd5d7807c62e85c6b3495ac997e2e42fb2f164b30fc1d618216c9ab1c4ba8fL192-R193) [[2]](diffhunk://#diff-86fd5d7807c62e85c6b3495ac997e2e42fb2f164b30fc1d618216c9ab1c4ba8fL231-R232) [[3]](diffhunk://#diff-86fd5d7807c62e85c6b3495ac997e2e42fb2f164b30fc1d618216c9ab1c4ba8fL366-R367)
* [`backend/enmedd/server/auth_check.py`](diffhunk://#diff-c920e467c021324eb490d538952ae2f76931fff91b9254e430967c8f39e1a37aR105): Included `current_workspace_or_teamspace_admin_user` in the list of dependencies checked in `check_router_auth`.
* [`backend/enmedd/server/settings/api.py`](diffhunk://#diff-58a15e82c6da614f59fb8f68b582450d999c01ed5117bbe696180fec77e62706L71-R71): Updated the `put_settings` function to use `current_workspace_or_teamspace_admin_user` for authorization.

Imports Adjustment:

* Various files (`backend/ee/enmedd/server/teamspace/api.py`, `backend/enmedd/server/auth_check.py`, `backend/enmedd/server/settings/api.py`): Added imports for `current_workspace_or_teamspace_admin_user`. [[1]](diffhunk://#diff-86fd5d7807c62e85c6b3495ac997e2e42fb2f164b30fc1d618216c9ab1c4ba8fR25) [[2]](diffhunk://#diff-c920e467c021324eb490d538952ae2f76931fff91b9254e430967c8f39e1a37aR12) [[3]](diffhunk://#diff-58a15e82c6da614f59fb8f68b582450d999c01ed5117bbe696180fec77e62706L12-R14)



## Checklist:
- [ ] All of the automated tests pass
- [ ] All changes has been tested locally through Docker
- [ ] If there are database revisions, all the Docker files are updated
- [ ] If there are new dependencies, they are added to the requirements text files
- [ ] If there are new environment variables, they are added to all of the deployment methods
- [ ] If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- [ ] Author has done a final read through of the PR right before merge
