### PR TITLE
fix: remove user dependencies; use /workspace/logo public endpoint

### DIFF
--- a/backend/ee/enmedd/server/workspace/api.py
+++ b/backend/ee/enmedd/server/workspace/api.py
@@ -22,7 +22,6 @@ from ee.enmedd.server.workspace.store import load_analytics_script
 from ee.enmedd.server.workspace.store import store_analytics_script
 from ee.enmedd.server.workspace.store import upload_header_logo
 from ee.enmedd.server.workspace.store import upload_logo
-from enmedd.auth.users import current_user
 from enmedd.auth.users import current_user_with_expired_token
 from enmedd.auth.users import current_workspace_admin_user
 from enmedd.auth.users import get_user_manager
@@ -263,7 +262,6 @@ def fetch_logotype(db_session: Session = Depends(get_session)) -> Response:
 @basic_router.get("/logo")
 def fetch_logo(
     workspace_id: int = 0,  # Temporary setting workspace_id to 0
-    _: User | None = Depends(current_user),
     db_session: Session = Depends(get_session),
 ) -> Response:
     try:

--- a/web/src/components/Logo.tsx
+++ b/web/src/components/Logo.tsx
@@ -3,7 +3,6 @@
 import { useContext } from "react";
 import { SettingsContext } from "./settings/SettingsProvider";
 import Image from "next/image";
-import { buildImgUrl } from "@/app/chat/files/images/utils";
 
 export function Logo({
   height,
@@ -41,7 +40,7 @@ export function Logo({
   return (
     <div style={{ height, width }} className={`relative ${className}`}>
       <img
-        src={buildImgUrl(settings.workspaces?.custom_logo)}
+        src={"/api/workspace/logo?workspace_id=" + 0}
         alt="Logo"
         style={{ objectFit: "cover", height, width, borderRadius: "8px" }}
         width={width}


### PR DESCRIPTION
## Description
This pull request includes changes to both the backend and frontend of the application to update how logos are handled and fetched. The most important changes include removing the `current_user` dependency, modifying the logo fetching function, and updating the logo component to use a new API endpoint.

Backend changes:

* [`backend/ee/enmedd/server/workspace/api.py`](diffhunk://#diff-a5504cf26ea778f560a4ab1bfbb3e166e5e9cc948522d9ced67f505eadb708d5L266): Removed the `current_user` dependency from the `fetch_logo` function.
* [`backend/ee/enmedd/server/workspace/api.py`](diffhunk://#diff-a5504cf26ea778f560a4ab1bfbb3e166e5e9cc948522d9ced67f505eadb708d5L25): Removed the import of `current_user` from `enmedd.auth.users`.

Frontend changes:

* [`web/src/components/Logo.tsx`](diffhunk://#diff-1cce2d3220af982e640cbb7cb1bc5d2a4cedfaf6644d124283f111b462cd6618L6): Removed the import of `buildImgUrl` utility function.
* [`web/src/components/Logo.tsx`](diffhunk://#diff-1cce2d3220af982e640cbb7cb1bc5d2a4cedfaf6644d124283f111b462cd6618L44-R43): Updated the `src` attribute in the `Logo` component to use the new API endpoint for fetching the logo.


## How Has This Been Tested?
[Describe the tests you ran to verify your changes]


## Accepted Risk (provide if relevant)
N/A


## Related Issue(s) (provide if relevant)
N/A


## Mental Checklist:
- All of the automated tests pass
- All PR comments are addressed and marked resolved
- If there are migrations, they have been rebased to latest main
- If there are new dependencies, they are added to the requirements
- If there are new environment variables, they are added to all of the deployment methods
- If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- Docker images build and basic functionalities work
- Author has done a final read through of the PR right before merge

## Backporting (check the box to trigger backport action)
Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.
- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
