### PR TITLE
hotfix/remove-pagination-temporarily

### DIFF
--- a/backend/enmedd/server/manage/models.py
+++ b/backend/enmedd/server/manage/models.py
@@ -142,9 +142,7 @@ class FullModelVersionResponse(BaseModel):
 
 class AllUsersResponse(BaseModel):
     accepted: list[FullUserSnapshot]
-    invited: list[InvitedUserSnapshot]
-    accepted_pages: int
-    invited_pages: int
+    invited: list[InvitedUserSnapshot]  #
 
 
 class OTPVerificationRequest(BaseModel):


### PR DESCRIPTION
## Description
This pull request includes changes to the user management functionality in the `backend/enmedd/server/manage` module. The changes simplify the handling of user lists by removing pagination and filtering invited users who are already accepted.

Changes to user management:

* [`backend/enmedd/server/manage/models.py`](diffhunk://#diff-ee62cb55666e75ecc21e652e8dd1ca1db334c7ac1dc3d414229ce8269423a235L145-R145): Removed pagination attributes (`accepted_pages`, `invited_pages`) from the `AllUsersResponse` model.
* [`backend/enmedd/server/manage/users.py`](diffhunk://#diff-a024d5a4d9a09aceba1bc5a23d83841538caa7224ed2306ffff239b3cbe74556L329-L337): Removed pagination parameters (`accepted_page`, `invited_page`) from the `list_all_users` function.
* [`backend/enmedd/server/manage/users.py`](diffhunk://#diff-a024d5a4d9a09aceba1bc5a23d83841538caa7224ed2306ffff239b3cbe74556R362-R375): Added filtering to exclude invited users who are already accepted in the `list_all_users` function.



## Checklist:
- [ ] All of the automated tests pass
- [ ] All changes has been tested locally through Docker
- [ ] If there are database revisions, all the Docker files are updated
- [ ] If there are new dependencies, they are added to the requirements text files
- [ ] If there are new environment variables, they are added to all of the deployment methods
- [ ] If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- [x] Author has done a final read through of the PR right before merge
