### PR TITLE
Feat/backend/feature flag decorator

### DIFF
--- a/backend/enmedd/server/enmedd_api/ingestion.py
+++ b/backend/enmedd/server/enmedd_api/ingestion.py
@@ -21,6 +21,7 @@ from enmedd.indexing.indexing_pipeline import build_indexing_pipeline
 from enmedd.server.enmedd_api.models import DocMinimalInfo
 from enmedd.server.enmedd_api.models import IngestionDocument
 from enmedd.server.enmedd_api.models import IngestionResult
+from enmedd.server.feature_flags.models import feature_flag
 from enmedd.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -47,6 +48,7 @@ def get_docs_by_connector_credential_pair(
 
 
 @router.get("/ingestion")
+@feature_flag("ingestion_api", default=True)
 def get_ingestion_docs(
     _: User | None = Depends(api_key_dep),
     db_session: Session = Depends(get_session),
@@ -63,6 +65,7 @@ def get_ingestion_docs(
 
 
 @router.post("/ingestion")
+@feature_flag("ingestion_api", default=True)
 def upsert_ingestion_doc(
     doc_info: IngestionDocument,
     _: User | None = Depends(api_key_dep),

--- a/backend/enmedd/server/feature_flags/models.py
+++ b/backend/enmedd/server/feature_flags/models.py
@@ -32,19 +32,20 @@ class FeatureFlags(BaseModel):
 
 
 class FeatureFlagsManager:
-    def __reload_features() -> dict:
+    @staticmethod
+    def _reload_features() -> dict:
         return get_kv_store().load(_FEATURE_FLAG_KEY)
 
     def is_feature_enabled(feature: str, default: bool = False) -> bool:
         try:
-            features = FeatureFlagsManager.__reload_features()
+            features = FeatureFlagsManager._reload_features()
             return not not features.get(feature)
         except TypeError:
             return default
 
     def get_all_features():
         try:
-            return FeatureFlagsManager.__reload_features()
+            return FeatureFlagsManager._reload_features()
         except KvKeyNotFoundError:
             # Initialize the default feature flags. This is used when the feature flags are not set
             feature_flag = FeatureFlags()
@@ -70,7 +71,7 @@ def feature_flag(feature_name: str, default: bool = False):
             logger.info(f"Checking feature flag {feature_name}")
 
             # If the feature is not in the existing features, store it with the default value
-            existing_features = FeatureFlagsManager.__reload_features()
+            existing_features = FeatureFlagsManager.get_all_features()
             if feature_name not in existing_features:
                 FeatureFlagsManager.store_feature(feature_name, default)
 

--- a/backend/enmedd/server/manage/users.py
+++ b/backend/enmedd/server/manage/users.py
@@ -67,6 +67,7 @@ from enmedd.db.users import get_user_by_email
 from enmedd.db.users import list_users
 from enmedd.file_store.file_store import get_default_file_store
 from enmedd.key_value_store.factory import get_kv_store
+from enmedd.server.feature_flags.models import feature_flag
 from enmedd.server.manage.models import AllUsersResponse
 from enmedd.server.manage.models import OTPVerificationRequest
 from enmedd.server.manage.models import UserByEmail
@@ -634,6 +635,7 @@ def get_current_token_creation(
 
 
 @router.put("/me/profile")
+@feature_flag("profile_page")
 def put_profile(
     file: UploadFile,
     db_session: Session = Depends(get_session),
@@ -643,6 +645,7 @@ def put_profile(
 
 
 @router.get("/me/profile")
+@feature_flag("profile_page")
 def fetch_profile(
     db_session: Session = Depends(get_session),
     current_user: User = Depends(current_user),
@@ -659,6 +662,7 @@ def fetch_profile(
 
 
 @router.delete("/me/profile")
+@feature_flag("profile_page")
 def remove_profile(
     db_session: Session = Depends(get_session),
     current_user: User = Depends(current_user),  # Get the current user


### PR DESCRIPTION
## Description
This pull request introduces feature flagging capabilities to the `backend/enmedd/server` module, allowing for more controlled and gradual feature rollouts. The most important changes include the addition of a **feature flag decorator**, the **integration of feature flags into existing API endpoints**, and the **initialization of default feature flags**.

### Feature flagging:

* [`backend/enmedd/server/feature_flags/models.py`](diffhunk://#diff-405070bb9dff1ab053f09ac18b8051455258bd33a99d80a8e7887d699f77b4d8R1-R3): Added a `feature_flag` decorator to check if a feature flag is enabled before executing a function. This includes logging, checking existing features, and raising an HTTP exception if the feature is disabled. [[1]](diffhunk://#diff-405070bb9dff1ab053f09ac18b8051455258bd33a99d80a8e7887d699f77b4d8R1-R3) [[2]](diffhunk://#diff-405070bb9dff1ab053f09ac18b8051455258bd33a99d80a8e7887d699f77b4d8L55-R86)
* [`backend/enmedd/server/feature_flags/models.py`](diffhunk://#diff-405070bb9dff1ab053f09ac18b8051455258bd33a99d80a8e7887d699f77b4d8R28-R29): Modified the `FeatureFlags` class to allow extra attributes and updated the `update_overall_feature` method to handle `FeatureFlags` instances. [[1]](diffhunk://#diff-405070bb9dff1ab053f09ac18b8051455258bd33a99d80a8e7887d699f77b4d8R28-R29) [[2]](diffhunk://#diff-405070bb9dff1ab053f09ac18b8051455258bd33a99d80a8e7887d699f77b4d8L55-R86)
* [`backend/enmedd/server/feature_flags/models.py`](diffhunk://#diff-405070bb9dff1ab053f09ac18b8051455258bd33a99d80a8e7887d699f77b4d8R49): Added initialization of default feature flags when they are not set.

### Integration of feature flags into existing endpoints:

* [`backend/enmedd/server/enmedd_api/ingestion.py`](diffhunk://#diff-212937e87b1959661ea95d487897eacc86126703b75f4f8adee770376247cfefR51): Applied the `feature_flag` decorator to the `get_ingestion_docs` and `upsert_ingestion_doc` endpoints with the "ingestion_api" feature flag. [[1]](diffhunk://#diff-212937e87b1959661ea95d487897eacc86126703b75f4f8adee770376247cfefR51) [[2]](diffhunk://#diff-212937e87b1959661ea95d487897eacc86126703b75f4f8adee770376247cfefR68)
* [`backend/enmedd/server/manage/users.py`](diffhunk://#diff-a024d5a4d9a09aceba1bc5a23d83841538caa7224ed2306ffff239b3cbe74556R638): Applied the `feature_flag` decorator to the `put_profile`, `fetch_profile`, and `remove_profile` endpoints with the "profile_page" feature flag. [[1]](diffhunk://#diff-a024d5a4d9a09aceba1bc5a23d83841538caa7224ed2306ffff239b3cbe74556R638) [[2]](diffhunk://#diff-a024d5a4d9a09aceba1bc5a23d83841538caa7224ed2306ffff239b3cbe74556R648) [[3]](diffhunk://#diff-a024d5a4d9a09aceba1bc5a23d83841538caa7224ed2306ffff239b3cbe74556R665)



## Checklist:
- [ ] All of the automated tests pass
- [x] All changes has been tested locally through Docker
- [ ] If there are database revisions, all the Docker files are updated
- [ ] If there are new dependencies, they are added to the requirements text files
- [ ] If there are new environment variables, they are added to all of the deployment methods
- [ ] If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- [x] Author has done a final read through of the PR right before merge
