### PR TITLE
fix: change toast status to variant 'destructive' for invalid file type

### DIFF
--- a/web/src/app/t/[teamspaceId]/admin/settings/TabContent/General.tsx
+++ b/web/src/app/t/[teamspaceId]/admin/settings/TabContent/General.tsx
@@ -150,7 +150,7 @@ export default function General({
         toast({
           title: "Invalid file type",
           description: "Please upload a valid image file.",
-          status: "error",
+          variant: "destructive",
         });
       }
     };


### PR DESCRIPTION
## Description
This pull request includes a small change to the `General` component in the `TabContent` directory. The change modifies the `toast` function to use a different variant for error messages.

* `web/src/app/t/[teamspaceId]/admin/settings/TabContent/General.tsx`: Changed the `toast` function's `status` property from `"error"` to `variant: "destructive"` to better reflect the nature of the error message. ([web/src/app/t/[teamspaceId]/admin/settings/TabContent/General.tsxL153-R153](diffhunk://#diff-365cddb9e31d9f92beba37bd9110000bb43ea71f3337623d43f9a66e83d6f245L153-R153))



## Checklist:
- [ ] All of the automated tests pass
- [ ] All changes has been tested locally through Docker
- [ ] If there are database revisions, all the Docker files are updated
- [ ] If there are new dependencies, they are added to the requirements text files
- [ ] If there are new environment variables, they are added to all of the deployment methods
- [ ] If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- [ ] Author has done a final read through of the PR right before merge
