### PR TITLE
fix: render for html in verification email template

### DIFF
--- a/backend/enmedd/auth/users.py
+++ b/backend/enmedd/auth/users.py
@@ -294,7 +294,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
             subject, body = generate_user_verification_email(
                 user.full_name, link, db_session
             )
-            send_mail(user.email, subject, body, smtp_credentials)
+            send_mail(user.email, subject, body, smtp_credentials, True)
 
     async def authenticate(
         self, credentials: OAuth2PasswordRequestForm


### PR DESCRIPTION
## Description
This commit contains a simple fix for account verification email template. This change simply sets the MIME type of the said template to be rendered as HTML.



## Checklist:
- [ ] All of the automated tests pass
- [ ] All changes has been tested locally through Docker
- [ ] If there are database revisions, all the Docker files are updated
- [ ] If there are new dependencies, they are added to the requirements text files
- [ ] If there are new environment variables, they are added to all of the deployment methods
- [ ] If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- [ ] Author has done a final read through of the PR right before merge
