### PR TITLE
Fix/signup common domain restrictions

### DIFF
--- a/backend/enmedd/auth/users.py
+++ b/backend/enmedd/auth/users.py
@@ -111,7 +111,7 @@ def user_needs_to_be_verified() -> bool:
     return AUTH_TYPE != AuthType.BASIC or REQUIRE_EMAIL_VERIFICATION
 
 
-def verify_email_is_invited(email: str) -> None:
+def verify_email_is_invited(email: str) -> bool | None:
     whitelist = get_invited_users(all=True)
     if not whitelist:
         raise PermissionError("No Users are invited yet")
@@ -132,7 +132,7 @@ def verify_email_is_invited(email: str) -> None:
         # oddly, normalization does not include lowercasing the user part of the
         # email address ... which we want to allow
         if email_info.normalized.lower() == email_info_whitelist.normalized.lower():
-            return
+            return True
 
     raise PermissionError("User not on allowed user whitelist")
 
@@ -143,35 +143,39 @@ def verify_email_in_whitelist(email: str) -> None:
             verify_email_is_invited(email)
 
 
-def verify_email_domain(email: str, for_signup: bool | None = None) -> None:
+def verify_email_domain(email: str) -> None:
     if email.count("@") != 1:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Email is not valid",
         )
 
+    # check if the email is in the environ whitelist
     domain = email.split("@")[-1]
-
-    # strict checking if the email is under a company email
-    if domain in CONSIDERED_COMMON_SMTP_DOMAINS:
-        try:
-            verify_email_is_invited(email)
-        except Exception:
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="The email provided is not allowed to sign-in (not invited)",
-            )
-
-    # check if the email is in the whitelist
     if VALID_EMAIL_DOMAINS:
-        if domain not in VALID_EMAIL_DOMAINS:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="Email domain is not valid",
-            )
+        if domain in VALID_EMAIL_DOMAINS:
+            return
 
-        if for_signup:
-            verify_email_is_invited(email)
+    # retrieve the existing company emails
+    registered_mails = get_invited_users(all=True)
+    whitelisted_domains = set()
+
+    # retrieve only the email domains that are not common (gmail, etc.)
+    for mails in registered_mails:
+        logger.debug(f"mails: {mails}")
+        if mails.count("@") == 1:
+            registered_domain = mails.split("@")[-1]
+            if registered_domain not in CONSIDERED_COMMON_SMTP_DOMAINS:
+                whitelisted_domains.add(registered_domain)
+
+    if domain not in whitelisted_domains:
+        if verify_email_is_invited(email):
+            return
+
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="The email domain provided is not allowed to sign up (not invited)",
+        )
 
 
 class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
@@ -186,13 +190,14 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         request: Optional[Request] = None,
     ) -> User:
         # strict checking of allowed domain (invited or not)
-        verify_email_domain(user_create.email, True)
+        user_count = await get_user_count()
+        if user_count > 0 and user_create.email not in get_default_admin_user_emails():
+            verify_email_domain(user_create.email)
 
         # condition to check if the account created is the first account
         # first account -> set it to admin by default
         # other condition -> set the role based on the given role param (BASIC is the default)
         if hasattr(user_create, "role"):
-            user_count = await get_user_count()
             if user_count == 0 or user_create.email in get_default_admin_user_emails():
                 user_create.role = UserRole.ADMIN
             else:

--- a/backend/enmedd/configs/app_configs.py
+++ b/backend/enmedd/configs/app_configs.py
@@ -441,3 +441,25 @@ URL_USERAGENT = [
     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36 Edg\
     /131.0.2903.86",
 ]
+
+
+#####
+# list of the considered common smtp mail domains
+# this list will be considered as the domains that will be strictly checked
+# by the verifier to prevent random access from the random internet users
+#####
+CONSIDERED_COMMON_SMTP_DOMAINS = [
+    "gmail.com",
+    "mail.yahoo.com	",
+    "outlook.com",
+    "icloud.com",
+    "icloud.mail",
+    "comcast.net",
+    "att.net",
+    "aol.com",
+    "hotmail.com",
+    "proton.me",
+    "proton.com",
+    "pm.me",
+    "protonmail.ch",
+]

--- a/web/src/app/auth/signup/SignupForms.tsx
+++ b/web/src/app/auth/signup/SignupForms.tsx
@@ -116,9 +116,11 @@ export function SignupForms({ shouldVerify }: { shouldVerify?: boolean }) {
       const errorDetail = (await response.json()).detail;
 
       let errorMsg = "Unknown error";
+      if (errorDetail) errorMsg = errorDetail;
       if (errorDetail === "REGISTER_USER_ALREADY_EXISTS") {
         errorMsg = "An account already exist with the specified email.";
       }
+
       toast({
         title: "Sign Up Failed",
         description: `Failed to sign up - ${errorMsg}`,


### PR DESCRIPTION
## Description
Fix signup bypass allowing unauthorized account creation

- Resolved an issue where non-invited users could create accounts and access the platform for free.
- Updated the logic to validate SMTP domains by checking against the list of already invited users.
- For common SMTP domains like "gmail.com," only invited users are now permitted to create accounts.

This ensures stricter access control and prevents unauthorized use of the platform.


## Checklist:
- [ ] All of the automated tests pass
- [ ] All changes has been tested locally through Docker
- [ ] If there are database revisions, all the Docker files are updated
- [ ] If there are new dependencies, they are added to the requirements text files
- [ ] If there are new environment variables, they are added to all of the deployment methods
- [ ] If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- [ ] Author has done a final read through of the PR right before merge
