### PR TITLE
fix: remove teamspace_id from document fetch API call (#368)

### DIFF
--- a/web/src/app/admin/connector/DocumentViewerModal.tsx
+++ b/web/src/app/admin/connector/DocumentViewerModal.tsx
@@ -54,7 +54,7 @@ export function DocumentViewerModal({
         }
 
         const response = await fetch(
-          `/api/document/file?file_name=${fileLocation}&teamspace_id=${teamspaceId}`,
+          `/api/document/file?file_name=${fileLocation}`,
           {
             method: "GET",
             headers: {


### PR DESCRIPTION
## Description
This pull request includes a change to the `DocumentViewerModal` component in the `web/src/app/admin/connector/DocumentViewerModal.tsx` file. The change removes the `teamspace_id` parameter from the API request URL.

* [`web/src/app/admin/connector/DocumentViewerModal.tsx`](diffhunk://#diff-e856b97a7dea459240262b014e096f708e1a2bdba90b9c8e03c753add6d55981L57-R57): Removed the `teamspace_id` parameter from the API request URL in the `fetch` call.

## Dependencies
None

## Checklist:
- [x] Are there any merge conflicts? If there is, update your current branch with the latest version of the environment branch (e.g. `development-environment`) you are requesting to merge to.
- [x] Does the PR contain only a single feature / bug fix? If not, consider breaking it down.
- [x] Does the code follows the [Organization Coding Standards](https://aitable.ai/workbench/dstBUjfN2km2uTL7Ui/viwLfnJ30iHas?recordId=recEmvoxRXjGW&fieldId=fldP2q3QTsV7i)?
- [x] Do you think that the code complies with the [Code Review Checklist](https://aitable.ai/workbench/dstBUjfN2km2uTL7Ui/viwLfnJ30iHas?recordId=recvHJo8sGPpz&fieldId=fldP2q3QTsV7i#heading-2) criterias?
- [x] Does the code include unit tests and is added to the CI pipeline
- [x] Is the platform been tested in a full docker-compose build and run?
- [x] Is there a new dependencies introduces? If there is, are they added to the requirement text files (Python) and is included in the **Dependencies** section of this PR.
- [x] Is there new environment variables? If there is, add this to all deployment methods in the Docker Compose yaml files (you can see those under `/deployment/docker-compose` directory)
- [x] Is there new APIs? Make sure that the new API is documnted properly using Swagger. Learn more on how to use the Swagger documentation at the Section 4.2 of [Organization Coding Standards](https://aitable.ai/workbench/dstBUjfN2km2uTL7Ui/viwLfnJ30iHas?recordId=recEmvoxRXjGW&fieldId=fldP2q3QTsV7i#heading-10)
- [x] Is there new APIs that don't require authentication? If there is, add it into the `PUBLIC_ENDPOINT_SPECS` in the `/server/auth_check.py` file with the following format `(endpoint_name, {http_method})`
- [x] Author has done a final read throgh of the PR right before merge

