### PR TITLE
fix: added the proper name of the image file stored in the pg as param

### DIFF
--- a/backend/enmedd/chat/process_message.py
+++ b/backend/enmedd/chat/process_message.py
@@ -725,7 +725,9 @@ def stream_chat_message_objects(
                     )
 
                     ai_message_files = [
-                        FileDescriptor(id=str(file_id), type=ChatFileType.IMAGE, name=str(file_id))
+                        FileDescriptor(
+                            id=str(file_id), type=ChatFileType.IMAGE, name=str(file_id)
+                        )
                         for file_id in file_ids
                     ]
                     yield ImageGenerationDisplay(

--- a/backend/enmedd/chat/process_message.py
+++ b/backend/enmedd/chat/process_message.py
@@ -723,8 +723,9 @@ def stream_chat_message_objects(
                     file_ids = save_files_from_urls(
                         [img.url for img in img_generation_response]
                     )
+
                     ai_message_files = [
-                        FileDescriptor(id=str(file_id), type=ChatFileType.IMAGE)
+                        FileDescriptor(id=str(file_id), type=ChatFileType.IMAGE, name=str(file_id))
                         for file_id in file_ids
                     ]
                     yield ImageGenerationDisplay(

--- a/backend/enmedd/file_store/models.py
+++ b/backend/enmedd/file_store/models.py
@@ -20,7 +20,7 @@ class FileDescriptor(TypedDict):
 
     id: str
     type: ChatFileType
-    name: str | None
+    name: str | None = None
 
 
 class InMemoryChatFile(BaseModel):


### PR DESCRIPTION
**Ticket ID:** BUG-BE-379

## Description
This pull request addresses a bug in the image generation feature of the "art" assistant. The issue occurred when a prompt was processed successfully, and an image was generated, but an error was returned during chat finalization. The purpose of this fix is to ensure seamless functionality for users interacting with the "art" assistant. The change involves setting the `file_id` as the name in the `FileDescriptor` for AI-generated image files, resolving the error and enabling smooth completion of image generation prompts.


## Checklist:
- [x] Are there any merge conflicts? If there is, update your current branch with the latest version of the environment branch (e.g. `development-environment`) you are requesting to merge to.
- [ ] Does the PR contain only a single feature / bug fix? If not, consider breaking it down.
- [ ] Does the code follows the [Organization Coding Standards](https://aitable.ai/workbench/dstBUjfN2km2uTL7Ui/viwLfnJ30iHas?recordId=recEmvoxRXjGW&fieldId=fldP2q3QTsV7i)?
- [ ] Do you think that the code complies with the [Code Review Checklist](https://aitable.ai/workbench/dstBUjfN2km2uTL7Ui/viwLfnJ30iHas?recordId=recvHJo8sGPpz&fieldId=fldP2q3QTsV7i#heading-2) criterias?
- [ ] Does the code include unit tests and is added to the CI pipeline
- [ ] Is the platform been tested in a full docker-compose build and run?
- [ ] Is there a new dependencies introduces? If there is, are they added to the requirement text files (Python) and is included in the **Dependencies** section of this PR.
- [ ] Is there new environment variables? If there is, add this to all deployment methods in the Docker Compose yaml files (you can see those under `/deployment/docker-compose` directory)
- [ ] Is there new APIs? Make sure that the new API is documnted properly using Swagger. Learn more on how to use the Swagger documentation at the Section 4.2 of [Organization Coding Standards](https://aitable.ai/workbench/dstBUjfN2km2uTL7Ui/viwLfnJ30iHas?recordId=recEmvoxRXjGW&fieldId=fldP2q3QTsV7i#heading-10)
- [ ] Is there new APIs that don't require authentication? If there is, add it into the `PUBLIC_ENDPOINT_SPECS` in the `/server/auth_check.py` file with the following format `(endpoint_name, {http_method})`
- [ ] Author has done a final read throgh of the PR right before merge

