### PR TITLE
feat: add invite link generation and validation endpoints

### DIFF
--- a/backend/enmedd/auth/invited_users.py
+++ b/backend/enmedd/auth/invited_users.py
@@ -126,6 +126,8 @@ def decode_invite_token(token: str, email: str, db_session: Session):
             if not teamspace_id:
                 return "Missing teamspace_id"
             return teamspace_id
+        elif invite_token.emails == ["invite_link"]:
+            return teamspace_id
         else:
             delete_user_by_email(email, db_session)
             return "Invalid token"

--- a/backend/enmedd/connectors/xenforo/connector.py
+++ b/backend/enmedd/connectors/xenforo/connector.py
@@ -128,7 +128,9 @@ class XenforoConnector(LoadConnector):
     def __init__(self, base_url: str) -> None:
         self.base_url = base_url
         self.initial_run = not XenforoConnector.has_been_run_before
-        self.start = datetime.utcnow().replace(tzinfo=pytz.utc) - timedelta(days=1)
+        self.start = datetime.now(timezone.utc).replace(tzinfo=pytz.utc) - timedelta(
+            days=1
+        )
         self.cookies: dict[str, str] = {}
         # mimic user browser to avoid being blocked by the website (see: https://www.useragents.me/)
         self.headers = {

--- a/backend/enmedd/db/chat.py
+++ b/backend/enmedd/db/chat.py
@@ -1,6 +1,7 @@
 from collections.abc import Sequence
 from datetime import datetime
 from datetime import timedelta
+from datetime import timezone
 from typing import Optional
 from uuid import UUID
 
@@ -306,7 +307,7 @@ def delete_chat_session(
 
 
 def delete_chat_sessions_older_than(days_old: int, db_session: Session) -> None:
-    cutoff_time = datetime.utcnow() - timedelta(days=days_old)
+    cutoff_time = datetime.now(timezone.utc) - timedelta(days=days_old)
     old_sessions = db_session.execute(
         select(ChatSession.user_id, ChatSession.id).where(
             ChatSession.time_created < cutoff_time

--- a/backend/enmedd/server/auth_check.py
+++ b/backend/enmedd/server/auth_check.py
@@ -40,6 +40,7 @@ PUBLIC_ENDPOINT_SPECS = [
     ("/auth/verify-otp", {"POST"}),
     ("/users/generate-otp", {"PATCH"}),
     ("/users/validate-token-invite", {"POST"}),
+    ("/users/validate-invite-link", {"POST"}),
     ("/users/me", {"GET"}),
     ("/users/me", {"PATCH"}),
     ("/users/{id}", {"GET"}),


### PR DESCRIPTION
**Ticket ID:** FEATURE-BE-380 and FEATURE-BE-381
## Description

This pull request includes several changes to improve the handling of invite tokens and time-related operations in the `backend/enmedd` module. The most important changes involve updating datetime operations to use timezone-aware objects, adding new endpoints for invite link validation, and reorganizing imports for better code clarity.

## Dependencies

[Include here new dependencies introduced if there is one]

## Checklist:
- [x] Are there any merge conflicts? If there is, update your current branch with the latest version of the environment branch (e.g. `development-environment`) you are requesting to merge to.
- [x] Does the PR contain only a single feature / bug fix? If not, consider breaking it down.
- [x] Does the code follows the [Organization Coding Standards](https://aitable.ai/workbench/dstBUjfN2km2uTL7Ui/viwLfnJ30iHas?recordId=recEmvoxRXjGW&fieldId=fldP2q3QTsV7i)?
- [x] Do you think that the code complies with the [Code Review Checklist](https://aitable.ai/workbench/dstBUjfN2km2uTL7Ui/viwLfnJ30iHas?recordId=recvHJo8sGPpz&fieldId=fldP2q3QTsV7i#heading-2) criterias?
- [x] Does the code include unit tests and is added to the CI pipeline
- [x] Is the platform been tested in a full docker-compose build and run?
- [x] Is there a new dependencies introduces? If there is, are they added to the requirement text files (Python) and is included in the **Dependencies** section of this PR.
- [x] Is there new environment variables? If there is, add this to all deployment methods in the Docker Compose yaml files (you can see those under `/deployment/docker-compose` directory)
- [x] Is there new APIs? Make sure that the new API is documnted properly using Swagger. Learn more on how to use the Swagger documentation at the Section 4.2 of [Organization Coding Standards](https://aitable.ai/workbench/dstBUjfN2km2uTL7Ui/viwLfnJ30iHas?recordId=recEmvoxRXjGW&fieldId=fldP2q3QTsV7i#heading-10)
- [x] Is there new APIs that don't require authentication? If there is, add it into the `PUBLIC_ENDPOINT_SPECS` in the `/server/auth_check.py` file with the following format `(endpoint_name, {http_method})`
- [x] Author has done a final read throgh of the PR right before merge

