### PR TITLE
feat: handle unsupported file type

### DIFF
--- a/web/src/app/admin/connector/DocumentViewerModal.tsx
+++ b/web/src/app/admin/connector/DocumentViewerModal.tsx
@@ -11,7 +11,35 @@ import { Loading } from "@/components/Loading";
 
 function getFileType(fileName: string): string | undefined {
   const fileExtension = fileName.split(".").pop()?.toLowerCase();
-  const fileTypes: Record<string, string> = {
+  const allFileTypes: Record<string, string> = {
+    bmp: "Bitmap Image",
+    csv: "CSV File",
+    odt: "OpenDocument Text",
+    doc: "Word Document (Legacy)",
+    docx: "Word Document",
+    gif: "GIF Image",
+    htm: "HTML File",
+    html: "HTML File",
+    jpg: "JPEG Image",
+    jpeg: "JPEG Image",
+    pdf: "PDF Document",
+    png: "PNG Image",
+    ppt: "PowerPoint Presentation (Legacy)",
+    pptx: "PowerPoint Presentation",
+    tiff: "TIFF Image",
+    txt: "Text File",
+    xls: "Excel Spreadsheet (Legacy)",
+    xlsx: "Excel Spreadsheet",
+    mp4: "MP4 Video",
+    webp: "WebP Image",
+  };
+
+  return allFileTypes[fileExtension || ""];
+}
+
+function getDocSpecificFileType(fileName: string): string | undefined {
+  const fileExtension = fileName.split(".").pop()?.toLowerCase();
+  const specificFileTypes: Record<string, string> = {
     doc: "Word Document (Legacy)",
     docx: "Word Document",
     ppt: "PowerPoint Presentation (Legacy)",
@@ -20,7 +48,41 @@ function getFileType(fileName: string): string | undefined {
     xlsx: "Excel Spreadsheet",
   };
 
-  return fileTypes[fileExtension || ""];
+  return specificFileTypes[fileExtension || ""];
+}
+
+async function fetchAndPrepareDocument(
+  fileLocation: string,
+  title: string
+): Promise<IDocument> {
+  const allFileType = getFileType(fileLocation);
+  const docFileType = getDocSpecificFileType(fileLocation);
+
+  if (!allFileType) {
+    throw new Error(
+      `Unsupported file type for ${title}. Supported types: bmp, csv, odt, doc, docx, gif, htm, html, jpg, jpeg, pdf, png, ppt, pptx, tiff, txt, xls, xlsx, mp4, webp.`
+    );
+  }
+
+  const response = await fetch(`/api/document/file?file_name=${fileLocation}`, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error("Failed to fetch document");
+  }
+
+  const blob = await response.blob();
+  const fileURL = URL.createObjectURL(blob);
+
+  return {
+    uri: fileURL,
+    fileName: fileLocation,
+    ...(docFileType ? { fileType: docFileType } : {}), // Conditionally include docFileType
+  };
 }
 
 export function DocumentViewerModal({
@@ -33,62 +95,14 @@ export function DocumentViewerModal({
   const [openDocumentModal, setOpenDocumentModal] = useState(false);
   const [documentData, setDocumentData] = useState<IDocument[]>([]);
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
   const documents =
     ccPair.connector.connector_specific_config.file_locations.map(
       (location: string) => ({
         location,
       })
     );
-
-  useEffect(() => {
-    if (!openDocumentModal) return;
-
-    async function fetchDocument() {
-      setLoading(true);
-
-      try {
-        const fileLocation = documents[0].location;
-
-        if (!fileLocation) {
-          throw new Error("No document found");
-        }
-
-        const response = await fetch(
-          `/api/document/file?file_name=${fileLocation}`,
-          {
-            method: "GET",
-            headers: {
-              "Content-Type": "application/json",
-            },
-          }
-        );
-
-        if (!response.ok) {
-          throw new Error("Failed to fetch document");
-        }
-
-        const blob = await response.blob();
-        const fileURL = URL.createObjectURL(blob);
-
-        const fileType = getFileType(fileLocation);
-
-        // Only include the fileType if it is a supported type
-        const document: IDocument = {
-          uri: fileURL,
-          fileName: fileLocation,
-          ...(fileType ? { fileType } : {}), // Conditionally include fileType
-        };
-
-        setDocumentData([document]);
-      } catch (err) {
-        console.error(err);
-      } finally {
-        setLoading(false);
-      }
-    }
-
-    fetchDocument();
-  }, [openDocumentModal, ccPair]);
 
   const configEntries = Object.entries(
     buildConfigEntries(
@@ -101,9 +115,37 @@ export function DocumentViewerModal({
     return null;
   }
 
-  const modalTitle = configEntries
+  const title = configEntries
     .map(([key, value]) => `${Array.isArray(value) ? value.join(", ") : value}`)
     .join(" | ");
+
+  useEffect(() => {
+    if (!openDocumentModal) return;
+
+    async function fetchDocument() {
+      setLoading(true);
+      setError(null);
+
+      try {
+        const fileLocation = documents[0].location;
+
+        if (!fileLocation) {
+          throw new Error("No document found");
+        }
+
+        const document = await fetchAndPrepareDocument(fileLocation, title);
+
+        setDocumentData([document]);
+      } catch (err: any) {
+        setError(err.message);
+        console.error(err);
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    fetchDocument();
+  }, [openDocumentModal, ccPair]);
 
   return (
     <div>
@@ -115,10 +157,13 @@ export function DocumentViewerModal({
             View
           </Button>
         }
-        title={modalTitle}
+        title={title}
+        headerClassName="pb-4"
       >
         {loading ? (
           <Loading />
+        ) : error ? (
+          <div className="text-destructive-500">{error}</div>
         ) : (
           <DocViewer
             prefetchMethod="GET"


### PR DESCRIPTION
## Description
**Ticket ID:** BUG-FE-383

The main purpose of this PR is to implement error handling and ensure that when unsupported files are loaded into the Document Viewer, an appropriate error message is displayed to the user. This will improve the user experience by providing clear feedback when a file format is not supported.

## Checklist:
- [x] Are there any merge conflicts? If there is, update your current branch with the latest version of the environment branch (e.g. `development-environment`) you are requesting to merge to.
- [x] Does the PR contain only a single feature / bug fix? If not, consider breaking it down.
- [x] Does the code follows the [Organization Coding Standards](https://aitable.ai/workbench/dstBUjfN2km2uTL7Ui/viwLfnJ30iHas?recordId=recEmvoxRXjGW&fieldId=fldP2q3QTsV7i)?
- [x] Do you think that the code complies with the [Code Review Checklist](https://aitable.ai/workbench/dstBUjfN2km2uTL7Ui/viwLfnJ30iHas?recordId=recvHJo8sGPpz&fieldId=fldP2q3QTsV7i#heading-2) criterias?
- [x] Does the code include unit tests and is added to the CI pipeline
- [x] Is the platform been tested in a full docker-compose build and run?
- [x] Is there a new dependencies introduces? If there is, are they added to the requirement text files (Python) and is included in the **Dependencies** section of this PR.
- [x] Is there new environment variables? If there is, add this to all deployment methods in the Docker Compose yaml files (you can see those under `/deployment/docker-compose` directory)
- [x] Is there new APIs? Make sure that the new API is documnted properly using Swagger. Learn more on how to use the Swagger documentation at the Section 4.2 of [Organization Coding Standards](https://aitable.ai/workbench/dstBUjfN2km2uTL7Ui/viwLfnJ30iHas?recordId=recEmvoxRXjGW&fieldId=fldP2q3QTsV7i#heading-10)
- [x] Is there new APIs that don't require authentication? If there is, add it into the `PUBLIC_ENDPOINT_SPECS` in the `/server/auth_check.py` file with the following format `(endpoint_name, {http_method})`
- [x] Author has done a final read throgh of the PR right before merge

