### PR TITLE
fix: sidebar is above generated image when inspecting

### DIFF
--- a/web/src/app/chat/files/images/FullImageModal.tsx
+++ b/web/src/app/chat/files/images/FullImageModal.tsx
@@ -22,7 +22,7 @@ export function FullImageModal({
   return (
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
       <Dialog.Portal>
-        <Dialog.Overlay className="fixed inset-0 bg-background-inverted bg-opacity-80 z-50" />
+        <Dialog.Overlay className="fixed inset-0 bg-background-inverted bg-opacity-80 z-modal" />
         <Dialog.Content
           className={`fixed 
             inset-0 
@@ -30,7 +30,7 @@ export function FullImageModal({
             items-center 
             justify-center
             p-4 
-            z-masked
+            z-modal
             max-w-screen-lg 
             h-fit 
             top-1/2 
@@ -41,7 +41,7 @@ export function FullImageModal({
           <img
             src={buildImgUrl(fileId)}
             alt="Uploaded image"
-            className="max-w-full max-h-full"
+            className="max-w-full max-h-full rounded-md"
           />
         </Dialog.Content>
       </Dialog.Portal>

--- a/web/src/app/chat/message/Messages.tsx
+++ b/web/src/app/chat/message/Messages.tsx
@@ -395,7 +395,7 @@ export const AIMessage = ({
             )}
         </div>
 
-        <div className="pl-1.5 md:pl-14 break-words w-full">
+        <div className="pl-1.5 md:pl-14 break-words w-full pt-4">
           {!toolCall || toolCall.tool_name === SEARCH_TOOL_NAME ? (
             <>
               {query !== undefined &&


### PR DESCRIPTION
## Description
**Ticket ID:** BUG-FE-383

The purpose of this PR is to fix the layering issue where the sidebar and global sidebar are appearing above the backdrop when inspecting an image. This problem can interfere with the image inspection experience by obscuring the view or causing layout inconsistencies. The fix ensures that the backdrop and content are layered correctly to provide a smoother, more intuitive interface for users.

## Checklist:
- [x] Are there any merge conflicts? If there is, update your current branch with the latest version of the environment branch (e.g. `development-environment`) you are requesting to merge to.
- [x] Does the PR contain only a single feature / bug fix? If not, consider breaking it down.
- [x] Does the code follows the [Organization Coding Standards](https://aitable.ai/workbench/dstBUjfN2km2uTL7Ui/viwLfnJ30iHas?recordId=recEmvoxRXjGW&fieldId=fldP2q3QTsV7i)?
- [x] Do you think that the code complies with the [Code Review Checklist](https://aitable.ai/workbench/dstBUjfN2km2uTL7Ui/viwLfnJ30iHas?recordId=recvHJo8sGPpz&fieldId=fldP2q3QTsV7i#heading-2) criterias?
- [x] Does the code include unit tests and is added to the CI pipeline
- [x] Is the platform been tested in a full docker-compose build and run?
- [x] Is there a new dependencies introduces? If there is, are they added to the requirement text files (Python) and is included in the **Dependencies** section of this PR.
- [x] Is there new environment variables? If there is, add this to all deployment methods in the Docker Compose yaml files (you can see those under `/deployment/docker-compose` directory)
- [x] Is there new APIs? Make sure that the new API is documnted properly using Swagger. Learn more on how to use the Swagger documentation at the Section 4.2 of [Organization Coding Standards](https://aitable.ai/workbench/dstBUjfN2km2uTL7Ui/viwLfnJ30iHas?recordId=recEmvoxRXjGW&fieldId=fldP2q3QTsV7i#heading-10)
- [x] Is there new APIs that don't require authentication? If there is, add it into the `PUBLIC_ENDPOINT_SPECS` in the `/server/auth_check.py` file with the following format `(endpoint_name, {http_method})`
- [x] Author has done a final read throgh of the PR right before merge

